### PR TITLE
update to version 4.0.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-# Get an updated config.sub and config.guess
-cp $BUILD_PREFIX/share/gnuconfig/config.* .
 
-./configure --prefix="${PREFIX}"
-make -j${CPU_COUNT}
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
-make check
-fi
-make install
+meson setup ${MESON_ARGS} builddir
+meson compile -j${CPU_COUNT} -C builddir
+meson install -C builddir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "3.4.1" %}
+{% set version = "4.0.0" %}
 
 package:
   name: openslide
   version: {{ version }}
 
 source:
-  url: https://github.com/openslide/openslide/releases/download/v{{ version }}/openslide-{{ version }}.tar.gz
-  sha256: fed08fab8a9b1ded95a34e196652291127ebe392c11f9bc13d26e760295a102d
+  url: https://github.com/openslide/openslide/releases/download/v{{ version }}/openslide-{{ version }}.tar.xz
+  sha256: cc227c44316abb65fb28f1c967706eb7254f91dbfab31e9ae6a48db6cf4ae562
 
 build:
-  number: 12
-  skip: True  # [win]
+  number: 0
+  skip: true  # [win]
   run_exports:
     # good compatibility in 3.X
     # https://abi-laboratory.pro/index.php?view=timeline&l=openslide
@@ -18,8 +18,7 @@ build:
 
 requirements:
   build:
-    - gnuconfig  # [unix]
-    - make  # [unix]
+    - meson  # [unix]
     - {{ compiler('c') }}
     - pkg-config
   host:
@@ -31,6 +30,7 @@ requirements:
     - libjpeg-turbo
     - openjpeg
     - openjpeg >=2.1
+    - libdicom
     - libpng
     - libtiff
     - libtiff >=4
@@ -48,7 +48,7 @@ about:
   home: http://openslide.org/
   license: LGPL 2.1
   license_family: LGPL
-  license_file: LICENSE.txt
+  license_file: COPYING.LESSER
   summary: OpenSlide is a C library that provides a simple interface to read whole-slide images (also known as virtual slides).
 
 extra:


### PR DESCRIPTION
this pull request implements changes for openslide version 4.0.0. specifically, this pr:

- replaces make with meson
- adds libdicom as a host requirement
- updates the license_file to `COPYING.LESSER`
- resets the build number to 0

fixes #22 
closes #23 

i do not run `meson test -C builddir` in `build.sh`. i can add that if desired.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


