### PR TITLE
test that the `slidetool` executable runs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/libopenslide${SHLIB_EXT}  # [unix]
-    - slidetool --help
+    - env OPENSLIDE_DEBUG=synthetic slidetool prop list ""  # [unix]
     - if not exist %LIBRARY_LIB%\libopenslide.dll exit 1   # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/libopenslide${SHLIB_EXT}  # [unix]
-    - env OPENSLIDE_DEBUG=synthetic slidetool prop list ""  # [unix]
+    - slidetool --help
     - if not exist %LIBRARY_LIB%\libopenslide.dll exit 1   # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/libopenslide${SHLIB_EXT}  # [unix]
-    - openslide-show-properties --help  # [unix]
+    - env OPENSLIDE_DEBUG=synthetic slidetool prop list ""  # [unix]
     - if not exist %LIBRARY_LIB%\libopenslide.dll exit 1   # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: cc227c44316abb65fb28f1c967706eb7254f91dbfab31e9ae6a48db6cf4ae562
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     # good compatibility in 3.X
@@ -42,6 +42,7 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/libopenslide${SHLIB_EXT}  # [unix]
+    - openslide-show-properties --help  # [unix]
     - if not exist %LIBRARY_LIB%\libopenslide.dll exit 1   # [win]
 
 about:


### PR DESCRIPTION
this pr proposes testing that `env OPENSLIDE_DEBUG=synthetic slidetool prop list ""` runs without error. i propose adding this test because when i install openslide 4.0.0 in a fresh conda environment, libdicom is not pulled in as a dependency.

```
$ mamba create -n test openslide
$ mamba activate test
$ env OPENSLIDE_DEBUG=synthetic slidetool prop list ""
slidetool: error while loading shared libraries: libdicom.so.1: cannot open shared object file: No such file or directory
```

running `mamba install libdicom` fixes the error, but why is libdicom not being pulled in automatically? it is present in the list of host dependencies in the openslide meta.yaml recipe.

here are the packages pulled in when i run `mamba create -n test openslide`:

```
  Package                      Version  Build          Channel           Size
───────────────────────────────────────────────────────────────────────────────
  Install:
───────────────────────────────────────────────────────────────────────────────

  + font-ttf-dejavu-sans-mono     2.37  hab24e00_0     conda-forge     Cached
  + font-ttf-inconsolata         3.000  h77eed37_0     conda-forge     Cached
  + font-ttf-source-code-pro     2.038  h77eed37_0     conda-forge     Cached
  + font-ttf-ubuntu               0.83  h77eed37_1     conda-forge     Cached
  + fonts-conda-forge                1  0              conda-forge     Cached
  + fonts-conda-ecosystem            1  0              conda-forge     Cached
  + _libgcc_mutex                  0.1  conda_forge    conda-forge     Cached
  + libstdcxx-ng                13.2.0  h7e041cc_3     conda-forge     Cached
  + libgomp                     13.2.0  h807b86a_3     conda-forge     Cached
  + _openmp_mutex                  4.5  2_gnu          conda-forge     Cached
  + libgcc-ng                   13.2.0  h807b86a_3     conda-forge     Cached
  + xorg-libxdmcp                1.1.3  h7f98852_0     conda-forge     Cached
  + pthread-stubs                  0.4  h36c2ea0_1001  conda-forge     Cached
  + xorg-xproto                 7.0.31  h7f98852_1007  conda-forge     Cached
  + xorg-kbproto                 1.0.7  h7f98852_1002  conda-forge     Cached
  + xorg-renderproto            0.11.1  h7f98852_1002  conda-forge     Cached
  + libexpat                     2.5.0  hcb278e6_1     conda-forge     Cached
  + libffi                       3.4.2  h7f98852_5     conda-forge     Cached
  + xorg-libxau                 1.0.11  hd590300_0     conda-forge     Cached
  + libwebp-base                 1.3.2  hd590300_0     conda-forge     Cached
  + libdeflate                    1.19  hd590300_0     conda-forge     Cached
  + lerc                         4.0.0  h27087fc_0     conda-forge     Cached
  + libjpeg-turbo                3.0.0  hd590300_1     conda-forge     Cached
  + libzlib                     1.2.13  hd590300_5     conda-forge     Cached
  + bzip2                        1.0.8  hd590300_5     conda-forge     Cached
  + xorg-xextproto               7.3.0  h0b41bf4_1003  conda-forge     Cached
  + libuuid                     2.38.1  h0b41bf4_0     conda-forge     Cached
  + xz                           5.2.6  h166bdaf_0     conda-forge     Cached
  + libiconv                      1.17  h166bdaf_0     conda-forge     Cached
  + gettext                     0.21.1  h27087fc_0     conda-forge     Cached
  + xorg-libice                  1.1.1  hd590300_0     conda-forge     Cached
  + pixman                      0.42.2  h59595ed_0     conda-forge     Cached
  + icu                           73.2  h59595ed_0     conda-forge     Cached
  + expat                        2.5.0  hcb278e6_1     conda-forge     Cached
  + libxcb                        1.15  h0b41bf4_0     conda-forge     Cached
  + zstd                         1.5.5  hfc55251_0     conda-forge     Cached
  + zlib                        1.2.13  hd590300_5     conda-forge     Cached
  + libsqlite                   3.44.2  h2797004_0     conda-forge     Cached
  + libpng                      1.6.39  h753d276_0     conda-forge     Cached
  + pcre2                        10.42  hcad00b1_0     conda-forge     Cached
  + xorg-libsm                   1.2.4  h7391055_0     conda-forge     Cached
  + libxml2                     2.12.2  h232c23b_0     conda-forge     Cached
  + xorg-libx11                  1.8.7  h8ee46fc_0     conda-forge     Cached
  + libtiff                      4.6.0  ha9c0a0a_2     conda-forge     Cached
  + freetype                    2.12.1  h267a509_2     conda-forge     Cached
  + libglib                     2.78.2  h783c2da_0     conda-forge     Cached
  + xorg-libxext                 1.3.4  h0b41bf4_2     conda-forge     Cached
  + xorg-libxrender             0.9.11  hd590300_0     conda-forge     Cached
  + openjpeg                     2.5.0  h488ebb8_3     conda-forge     Cached
  + fontconfig                  2.14.2  h14ed4e7_0     conda-forge     Cached
  + gdk-pixbuf                 2.42.10  h829c605_4     conda-forge     Cached
  + cairo                       1.18.0  h3faef2a_0     conda-forge     Cached
  + openslide                    4.0.0  h58ba908_0     conda-forge     Cached
```

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

