### PR TITLE
Drop liblzma-devel dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -24,8 +24,6 @@ glib:
 - '2'
 libjpeg_turbo:
 - '3'
-liblzma_devel:
-- '5'
 libpng:
 - '1.6'
 libtiff:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -24,8 +24,6 @@ glib:
 - '2'
 libjpeg_turbo:
 - '3'
-liblzma_devel:
-- '5'
 libpng:
 - '1.6'
 libtiff:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -24,8 +24,6 @@ glib:
 - '2'
 libjpeg_turbo:
 - '3'
-liblzma_devel:
-- '5'
 libpng:
 - '1.6'
 libtiff:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -24,8 +24,6 @@ glib:
 - '2'
 libjpeg_turbo:
 - '3'
-liblzma_devel:
-- '5'
 libpng:
 - '1.6'
 libtiff:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -24,8 +24,6 @@ glib:
 - '2'
 libjpeg_turbo:
 - '3'
-liblzma_devel:
-- '5'
 libpng:
 - '1.6'
 libtiff:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -16,8 +16,6 @@ glib:
 - '2'
 libjpeg_turbo:
 - '3'
-liblzma_devel:
-- '5'
 libpng:
 - '1.6'
 libtiff:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - windows-dll-name.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # good compatibility in 3.X
     # https://abi-laboratory.pro/index.php?view=timeline&l=openslide
@@ -45,8 +45,6 @@ requirements:
     - openjpeg
     - openjpeg >=2.1
     - libdicom
-    # https://github.com/conda-forge/libtiff-feedstock/issues/113
-    - liblzma-devel
     - libpng
     - libtiff
     - libtiff >=4


### PR DESCRIPTION
libtiff-feedstock now drops the `Requires.private` line from its pkg-config file.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.